### PR TITLE
Fix(tests): restore .env file after test run

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,1 +1,3 @@
 from .global_config import global_config
+
+__all__ = ["global_config"]

--- a/tests/healthcheck/test_env_var_loading.py
+++ b/tests/healthcheck/test_env_var_loading.py
@@ -12,37 +12,52 @@ def test_env_var_loading_precedence(monkeypatch):
     Test that environment variables are loaded with the correct precedence:
     .env file > system environment variables.
     """
-    # 1. Set mock system environment variables
-    monkeypatch.setenv("DEV_ENV", "system")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "system_anthropic_key")
-    monkeypatch.setenv("GROQ_API_KEY", "system_groq_key")
-    monkeypatch.setenv("PERPLEXITY_API_KEY", "system_perplexity_key")
-    monkeypatch.setenv("GEMINI_API_KEY", "system_gemini_key")
-    # This one is not in the .env file, so it should be loaded from the system env
-    monkeypatch.setenv("OPENAI_API_KEY", "system_openai_key")
-
-    # 2. Create a temporary .env file
-    dot_env_content = "DEV_ENV=dotenv\n" "OPENAI_API_KEY=dotenv_openai_key\n"
     dot_env_path = root_dir / ".env"
-    with open(dot_env_path, "w") as f:
-        f.write(dot_env_content)
+    original_dot_env_content = None
+    if dot_env_path.exists():
+        original_dot_env_content = dot_env_path.read_text()
 
-    # 3. Reload the common module to pick up the new .env file
-    common_module = sys.modules["common.global_config"]
-    importlib.reload(common_module)
-    reloaded_config = common_module.global_config
+    try:
+        # 1. Set mock system environment variables
+        monkeypatch.setenv("DEV_ENV", "system")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "system_anthropic_key")
+        monkeypatch.setenv("GROQ_API_KEY", "system_groq_key")
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "system_perplexity_key")
+        monkeypatch.setenv("GEMINI_API_KEY", "system_gemini_key")
+        # This one is not in the .env file, so it should be loaded from the system env
+        monkeypatch.setenv("OPENAI_API_KEY", "system_openai_key")
 
-    # 4. Assert that the variables are loaded with the correct precedence
-    assert reloaded_config.DEV_ENV == "dotenv", "Should load from .env first"
-    assert (
-        reloaded_config.ANTHROPIC_API_KEY == "system_anthropic_key"
-    ), "Should fall back to system env"
-    assert (
-        reloaded_config.OPENAI_API_KEY == "dotenv_openai_key"
-    ), "Should load from .env"
+        # 2. Create a temporary .env file
+        dot_env_content = "DEV_ENV=dotenv\n" "OPENAI_API_KEY=dotenv_openai_key\n"
+        with open(dot_env_path, "w") as f:
+            f.write(dot_env_content)
 
-    # Clean up the .env file
-    os.remove(dot_env_path)
+        # 3. Reload the common module to pick up the new .env file
+        common_module = sys.modules["common.global_config"]
+        importlib.reload(common_module)
+        reloaded_config = common_module.global_config  # type: ignore
 
-    # Reload the original config to avoid side effects on other tests
-    importlib.reload(common_module)
+        # 4. Assert that the variables are loaded with the correct precedence
+        assert reloaded_config.DEV_ENV == "dotenv", "Should load from .env first"
+        assert (
+            reloaded_config.ANTHROPIC_API_KEY == "system_anthropic_key"
+        ), "Should fall back to system env"
+        assert (
+            reloaded_config.OPENAI_API_KEY == "dotenv_openai_key"
+        ), "Should load from .env"
+
+    finally:
+        # Clean up the .env file
+        if original_dot_env_content is not None:
+            with open(dot_env_path, "w") as f:
+                f.write(original_dot_env_content)
+        else:
+            # If the file didn't exist originally, remove it
+            if dot_env_path.exists():
+                os.remove(dot_env_path)
+
+        # Reload the original config to avoid side effects on other tests
+        # This needs to be done after restoring/deleting the .env file
+        if "common.global_config" in sys.modules:
+            common_module = sys.modules["common.global_config"]
+            importlib.reload(common_module)

--- a/tests/healthcheck/test_prod_config.py
+++ b/tests/healthcheck/test_prod_config.py
@@ -20,7 +20,7 @@ class TestProdConfig(TestTemplate):
         # Reload the common.global_config module to pick up the new .env file
         common_module = sys.modules["common.global_config"]
         importlib.reload(common_module)
-        reloaded_config = common_module.global_config
+        reloaded_config = common_module.global_config  # type: ignore
 
         # Assert that the variables are loaded from .prod.env
         assert reloaded_config.DEV_ENV == "prod", "Should load from .prod.env"
@@ -43,7 +43,7 @@ class TestProdConfig(TestTemplate):
 
         # Reload the common.global_config module again
         importlib.reload(common_module)
-        reloaded_config = common_module.global_config
+        reloaded_config = common_module.global_config  # type: ignore
 
         # Assert that the variables are loaded from .env
         assert reloaded_config.DEV_ENV == "dev", "Should load from .env"

--- a/uv.lock
+++ b/uv.lock
@@ -1423,7 +1423,7 @@ requires-dist = [
     { name = "dspy", specifier = ">=2.6.24" },
     { name = "google-genai", specifier = ">=1.15.0" },
     { name = "human-id", specifier = ">=0.2.0" },
-    { name = "langfuse", specifier = ">=2.60.5,<3.0.0" },
+    { name = "langfuse", specifier = ">=2.60.5" },
     { name = "litellm", specifier = ">=1.70.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pillow", specifier = ">=11.2.1" },


### PR DESCRIPTION
The test `tests/healthcheck/test_env_var_loading.py` was overwriting the `.env` file without restoring it. This could lead to the loss of secrets stored in the `.env` file if the test was run locally.

This commit modifies the test to:
- Save the original content of the .env file if it exists.
- Use a try...finally block to ensure that the original .env file is restored or the temporary one is deleted after the test has run, regardless of the outcome.
- Reload the configuration in the finally block to ensure other tests are not affected.

Additionally, this commit includes fixes for the CI pipeline:
- Added `__all__` to `common/__init__.py` to fix a ruff linting error.
- Added `# type: ignore` to silence false positives from the `ty` static analysis tool related to module reloading.