### PR TITLE
Ci build failures resolution

### DIFF
--- a/tests/e2e/agent/test_agent.py
+++ b/tests/e2e/agent/test_agent.py
@@ -146,7 +146,7 @@ class TestAgent(E2ETestBase):
 
         response = self.client.post(
             "/agent",
-            data="not valid json",
+            content="not valid json",
             headers=self.auth_headers,
         )
 

--- a/tests/e2e/e2e_test_base.py
+++ b/tests/e2e/e2e_test_base.py
@@ -43,8 +43,14 @@ class E2ETestBase(TestTemplate):
         finally:
             db.close()
 
-    @pytest_asyncio.fixture
-    async def auth_headers(self, db: Session):
+    # NOTE:
+    # This fixture must be named `auth_headers` for existing tests, but we avoid
+    # defining a method named `auth_headers` because it conflicts with the
+    # instance attribute `self.auth_headers` that tests use. Some type checkers
+    # (e.g. ty) otherwise infer `self.auth_headers` as a union of a dict and a
+    # bound method.
+    @pytest_asyncio.fixture(name="auth_headers")
+    async def _auth_headers(self, db: Session) -> dict[str, str]:
         """
         Get authentication token for test user and approve them.
 


### PR DESCRIPTION
Fix `make ci` by resolving typing conflicts in E2E tests.

The `ty check` failed because `self.auth_headers` was inferred as a union of a dict and a bound method due to a conflicting fixture name. This PR renames the underlying fixture function to avoid the conflict and also corrects a `TestClient.post` argument from `data` to `content`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b63449e-a31f-40d2-ba30-193716c1fbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b63449e-a31f-40d2-ba30-193716c1fbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

