### PR TITLE
Codebase issue assessment

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,4 +10,16 @@ env =
     GROQ_API_KEY=test_api_key
     PERPLEXITY_API_KEY=test_api_key
     GEMINI_API_KEY=test_api_key
+    CEREBRAS_API_KEY=test_api_key
+    BACKEND_DB_URI=postgresql://user:pass@localhost:5432/test_db
+    TELEGRAM_BOT_TOKEN=test_telegram_bot_token
+    STRIPE_TEST_SECRET_KEY=sk_test_dummy
+    STRIPE_TEST_WEBHOOK_SECRET=whsec_test_dummy
+    STRIPE_SECRET_KEY=sk_live_dummy
+    STRIPE_WEBHOOK_SECRET=whsec_live_dummy
+    TEST_USER_EMAIL=test@example.com
+    TEST_USER_PASSWORD=test_password
+    WORKOS_API_KEY=test_workos_api_key
+    WORKOS_CLIENT_ID=client_test_123
+    SESSION_SECRET_KEY=test_session_secret_key
 


### PR DESCRIPTION
Fix WorkOS JWT signature verification bypass vulnerability and enable unit tests to run in a clean environment.

The `get_current_workos_user` function was incorrectly inferring "test mode" by checking if `sys.argv[0]` contained "test", which could accidentally disable JWT signature verification in a production environment. This PR removes this fragile check, ensuring verification is only skipped explicitly via `WORKOS_SKIP_JWT_VERIFICATION` or when running under `pytest`. Additionally, `pytest.ini` was updated with dummy environment variables to allow unit tests to run without a `.env` file, addressing a test setup issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cf1ff62-9877-448e-a1a0-5e82702a8056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6cf1ff62-9877-448e-a1a0-5e82702a8056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

