### PR TITLE
docs: fix outdated documentation (automated weekly drift check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ from common import global_config
 
 # Access config values
 global_config.example_parent.example_child
-global_config.llm_config.default_model
+global_config.default_llm.default_model
 
 # Access secrets from .env
 global_config.OPENAI_API_KEY

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -17,7 +17,7 @@ import { Step, Steps } from 'fumadocs-ui/components/steps';
 Create and activate your virtual environment using `uv`:
 
 ```bash
-make setup
+uv sync
 ```
 
 This will create a `.venv` directory and sync all dependencies from `pyproject.toml`.
@@ -51,7 +51,7 @@ make all
 Or run specific Python files directly:
 
 ```bash
-uv run python src/main.py
+uv run python main.py
 ```
 
 </Step>

--- a/manual_docs/branch_comparison.md
+++ b/manual_docs/branch_comparison.md
@@ -45,7 +45,7 @@ This document provides a detailed comparison of features available in the `main`
 |---------|:------:|:------:|-------|
 | pytest framework | ✅ | ✅ | Python testing |
 | TestTemplate base class | ✅ | ✅ | Shared test utilities |
-| pytest-asyncio | ✅ | ✅ | Async test support |
+| pytest-asyncio | ❌ | ✅ | Async test support |
 | E2E test structure | ❌ | ✅ | End-to-end testing patterns |
 
 ### Web Framework


### PR DESCRIPTION
This PR fixes outdated documentation identified during a weekly drift check.

Changes:
1.  **CLAUDE.md**: Corrected `global_config` attribute access pattern for LLM default model.
2.  **manual_docs/branch_comparison.md**: Updated feature matrix to reflect missing `pytest-asyncio` in `main` branch.
3.  **docs/content/docs/index.mdx**: Replaced nonexistent `make setup` command with `uv sync` and fixed incorrect file path for `main.py`.

---
*PR created automatically by Jules for task [17096332281359517951](https://jules.google.com/task/17096332281359517951) started by @Miyamura80*