### PR TITLE
docs: update quick start translations (es, ja, zh)

### DIFF
--- a/docs/content/docs/index.es.mdx
+++ b/docs/content/docs/index.es.mdx
@@ -1,11 +1,11 @@
 ---
-title: Inicio Rapido
+title: Inicio Rápido
 description: Comienza con esta plantilla de Python
 ---
 
-Bienvenido a la documentacion! Sigue estos pasos para comenzar con esta plantilla de Python.
+¡Bienvenido a la documentación! Sigue estos pasos para comenzar con esta plantilla de Python.
 
-## Inicio Rapido
+## Inicio Rápido
 
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
@@ -17,10 +17,10 @@ import { Step, Steps } from 'fumadocs-ui/components/steps';
 Crea y activa tu entorno virtual usando `uv`:
 
 ```bash
-make setup
+uv sync
 ```
 
-Esto creara un directorio `.venv` y sincronizara todas las dependencias de `pyproject.toml`.
+Esto creará un directorio `.venv` y sincronizará todas las dependencias de `pyproject.toml`.
 
 </Step>
 
@@ -34,24 +34,24 @@ Copia el archivo de entorno de ejemplo y agrega tus claves API:
 cp .env.example .env
 ```
 
-Edita `common/global_config.yaml` para personalizar los valores de configuracion de tu proyecto.
+Edita `common/global_config.yaml` para personalizar los valores de configuración de tu proyecto.
 
 </Step>
 
 <Step>
 
-### Ejecutar la Aplicacion
+### Ejecutar la Aplicación
 
-Ejecuta la aplicacion principal:
+Ejecuta la aplicación principal:
 
 ```bash
 make all
 ```
 
-O ejecuta archivos Python especificos directamente:
+O ejecuta archivos Python específicos directamente:
 
 ```bash
-uv run python src/main.py
+uv run python main.py
 ```
 
 </Step>
@@ -66,7 +66,7 @@ Verifica que todo funcione ejecutando el conjunto de pruebas:
 make test
 ```
 
-Ejecuta verificaciones de calidad de codigo:
+Ejecuta verificaciones de calidad de código:
 
 ```bash
 make ci
@@ -75,10 +75,10 @@ make ci
 </Step>
 </Steps>
 
-## Proximos Pasos
+## Próximos Pasos
 
 <Cards>
-  <Card title="Aprende mas sobre Configuracion" href="/docs/test" />
+  <Card title="Aprende más sobre Configuración" href="/docs/test" />
   <Card title="Referencia API" href="/docs/api" />
-  <Card title="Aprende mas sobre Fumadocs" href="https://fumadocs.dev" />
+  <Card title="Aprende más sobre Fumadocs" href="https://fumadocs.dev" />
 </Cards>

--- a/docs/content/docs/index.ja.mdx
+++ b/docs/content/docs/index.ja.mdx
@@ -17,7 +17,7 @@ import { Step, Steps } from 'fumadocs-ui/components/steps';
 `uv` を使用して仮想環境を作成し、有効化します：
 
 ```bash
-make setup
+uv sync
 ```
 
 これにより `.venv` ディレクトリが作成され、`pyproject.toml` のすべての依存関係が同期されます。
@@ -51,7 +51,7 @@ make all
 または特定の Python ファイルを直接実行します：
 
 ```bash
-uv run python src/main.py
+uv run python main.py
 ```
 
 </Step>

--- a/docs/content/docs/index.zh.mdx
+++ b/docs/content/docs/index.zh.mdx
@@ -17,7 +17,7 @@ import { Step, Steps } from 'fumadocs-ui/components/steps';
 使用 `uv` 创建并激活虚拟环境：
 
 ```bash
-make setup
+uv sync
 ```
 
 这将创建 `.venv` 目录并同步 `pyproject.toml` 中的所有依赖。
@@ -51,7 +51,7 @@ make all
 或直接运行特定 Python 文件：
 
 ```bash
-uv run python src/main.py
+uv run python main.py
 ```
 
 </Step>


### PR DESCRIPTION
Updates the Spanish (es), Japanese (ja), and Chinese (zh) translations of `docs/content/docs/index.mdx` to match the latest English source.

Changes:
- Updated code blocks to use `uv sync` and `uv run python main.py` instead of `make setup` and `make run`.
- Ensured structure and untranslated terms are preserved as per `docs/translation-guide.md`.
- Verified links and structure with `make docs_lint` and `make lint_links`.

English pages changed:
- docs/content/docs/index.mdx

Locales updated:
- es
- ja
- zh

Note: This is an automated translation and should be reviewed by native speakers.

---
*PR created automatically by Jules for task [5310045557195643239](https://jules.google.com/task/5310045557195643239) started by @Miyamura80*