### PR TITLE
docs: fix outdated documentation (automated weekly drift check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ result = await inf_module.run(input_field="value")
 
 ```python
 from tests.test_template import TestTemplate
-from tests.conftest import slow_test, nondeterministic_test
+from tests.test_template import slow_test, nondeterministic_test
 
 class TestMyFeature(TestTemplate):
     def test_something(self):


### PR DESCRIPTION
Fixes the incorrect import statements for test markers (`slow_test` and `nondeterministic_test`) in the documentation to accurately reflect their actual location in `tests.test_template`.

---
*PR created automatically by Jules for task [7209425350518636176](https://jules.google.com/task/7209425350518636176) started by @Miyamura80*