### PR TITLE
chore: prune unnecessary code (automated weekly cleanup)

### DIFF
--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -85,7 +85,7 @@ def scrub_sensitive_data(record):
     # Scrub exception if present
     exception = record.get("exception")
     if exception:
-        type_, value, tb = exception
+        _, value, _ = exception
         value_str = str(value)
         scrubbed_value_str = _SCRUBBER.scrub(value_str)
 


### PR DESCRIPTION
Removed unused variables `type_` and `tb` from `src/utils/logging_config.py`.

Evidence:
The variables `type_` and `tb` were obtained by unpacking `exception` tuple from the log record in `scrub_sensitive_data`. They were not used anywhere else in the function.

I have thoroughly checked `vulture` output against `UNNECESSARY_CODE_GUIDELINE.md` constraints. All other variables reported as unused (like `get_field_value`, `to_dict`, `setup_logging`) were either part of protected patterns (Pydantic models) or explicitly used in tests or documentation.

---
*PR created automatically by Jules for task [12370737117778100367](https://jules.google.com/task/12370737117778100367) started by @Miyamura80*