### PR TITLE
docs: fix outdated documentation (automated weekly drift check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <img alt="Project Version" src="https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMiyamura80%2FPython-Template%2Fmain%2Fpyproject.toml&query=%24.project.version&label=version&color=blue">
   <img alt="Python Version" src="https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FMiyamura80%2FPython-Template%2Fmain%2Fpyproject.toml&query=%24.project['requires-python']&label=python&logo=python&color=blue">
   <img alt="GitHub repo size" src="https://img.shields.io/github/repo-size/Miyamura80/Python-Template">
-  <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/Miyamura80/Python-Template/test_target_tests.yaml?branch=main">
+  <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/Miyamura80/Python-Template/a_test_target_tests.yml?branch=main">
 
 </p>
 


### PR DESCRIPTION
Fixes documentation drift where the GitHub Actions workflow status badge in `README.md` was pointing to a renamed workflow file (`test_target_tests.yaml` -> `a_test_target_tests.yml`).

Followed the OUTDATED_DOCUMENTATION_GUIDELINE.md strictly to only fix verifiably incorrect factual references.

---
*PR created automatically by Jules for task [17764249263775210469](https://jules.google.com/task/17764249263775210469) started by @Miyamura80*