### PR TITLE
🐛 fix make init to support re-initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,13 @@ init: ## Initialize project (usage: make init name=my-project description="my de
 	CURRENT_DESC=$$(sed -n 's/^description = "\(.*\)"/\1/p' pyproject.toml | head -1); \
 	ESC_NAME=$$(printf '%s\n' "$$CURRENT_NAME" | sed 's/[.[\*^$$\/]/\\&/g'); \
 	ESC_DESC=$$(printf '%s\n' "$$CURRENT_DESC" | sed 's/[.[\*^$$\/]/\\&/g'); \
+	ESC_NEW_NAME=$$(printf '%s\n' "$(name)" | sed 's/[&/\\]/\\&/g'); \
+	ESC_NEW_DESC=$$(printf '%s\n' "$(description)" | sed 's/[&|\\]/\\&/g'); \
 	echo "$(YELLOW)🚀 Initializing project $(name)...$(RESET)"; \
-	sed -i.bak "s/name = \"$$ESC_NAME\"/name = \"$(name)\"/" pyproject.toml && rm pyproject.toml.bak; \
-	sed -i.bak "s/description = \"$$ESC_DESC\"/description = \"$(description)\"/" pyproject.toml && rm pyproject.toml.bak; \
-	sed -i.bak "1s/^# .*/# $(name)/" README.md && rm README.md.bak; \
-	sed -i.bak "1,10s|<b>.*</b>|<b>$(description)</b>|" README.md && rm README.md.bak
+	sed -i.bak "s/name = \"$$ESC_NAME\"/name = \"$$ESC_NEW_NAME\"/" pyproject.toml && rm pyproject.toml.bak; \
+	sed -i.bak "s/description = \"$$ESC_DESC\"/description = \"$$ESC_NEW_DESC\"/" pyproject.toml && rm pyproject.toml.bak; \
+	sed -i.bak "1s/^# .*/# $$ESC_NEW_NAME/" README.md && rm README.md.bak; \
+	sed -i.bak "1,10s|<b>.*</b>|<b>$$ESC_NEW_DESC</b>|" README.md && rm README.md.bak
 	@echo "$(GREEN)✅ Updated project name and description.$(RESET)"
 
 banner: check_uv ## Generate project banner image

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,13 @@ init: ## Initialize project (usage: make init name=my-project description="my de
 	fi
 	@CURRENT_NAME=$$(sed -n 's/^name = "\(.*\)"/\1/p' pyproject.toml | head -1); \
 	CURRENT_DESC=$$(sed -n 's/^description = "\(.*\)"/\1/p' pyproject.toml | head -1); \
+	ESC_NAME=$$(printf '%s\n' "$$CURRENT_NAME" | sed 's/[.[\*^$$\/]/\\&/g'); \
+	ESC_DESC=$$(printf '%s\n' "$$CURRENT_DESC" | sed 's/[.[\*^$$\/]/\\&/g'); \
 	echo "$(YELLOW)🚀 Initializing project $(name)...$(RESET)"; \
-	sed -i.bak "s/name = \"$$CURRENT_NAME\"/name = \"$(name)\"/" pyproject.toml && rm pyproject.toml.bak; \
-	sed -i.bak "s/description = \"$$CURRENT_DESC\"/description = \"$(description)\"/" pyproject.toml && rm pyproject.toml.bak; \
+	sed -i.bak "s/name = \"$$ESC_NAME\"/name = \"$(name)\"/" pyproject.toml && rm pyproject.toml.bak; \
+	sed -i.bak "s/description = \"$$ESC_DESC\"/description = \"$(description)\"/" pyproject.toml && rm pyproject.toml.bak; \
 	sed -i.bak "1s/^# .*/# $(name)/" README.md && rm README.md.bak; \
-	sed -i.bak "s|<b>.*</b>|<b>$(description)</b>|" README.md && rm README.md.bak
+	sed -i.bak "1,10s|<b>.*</b>|<b>$(description)</b>|" README.md && rm README.md.bak
 	@echo "$(GREEN)✅ Updated project name and description.$(RESET)"
 
 banner: check_uv ## Generate project banner image

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,13 @@ init: ## Initialize project (usage: make init name=my-project description="my de
 		echo "Usage: make init name=<project_name> description=<project_description>"; \
 		exit 1; \
 	fi
-	@echo "$(YELLOW)🚀 Initializing project $(name)...$(RESET)"
-	@sed -i.bak "s/name = \"python-template\"/name = \"$(name)\"/" pyproject.toml && rm pyproject.toml.bak
-	@sed -i.bak "s/description = \"Add your description here\"/description = \"$(description)\"/" pyproject.toml && rm pyproject.toml.bak
-	@sed -i.bak "s/# Python-Template/# $(name)/" README.md && rm README.md.bak
-	@sed -i.bak "s/<b>Opinionated Python project stack. 🔋 Batteries included. <\/b>/<b>$(description)<\/b>/" README.md && rm README.md.bak
+	@CURRENT_NAME=$$(sed -n 's/^name = "\(.*\)"/\1/p' pyproject.toml | head -1); \
+	CURRENT_DESC=$$(sed -n 's/^description = "\(.*\)"/\1/p' pyproject.toml | head -1); \
+	echo "$(YELLOW)🚀 Initializing project $(name)...$(RESET)"; \
+	sed -i.bak "s/name = \"$$CURRENT_NAME\"/name = \"$(name)\"/" pyproject.toml && rm pyproject.toml.bak; \
+	sed -i.bak "s/description = \"$$CURRENT_DESC\"/description = \"$(description)\"/" pyproject.toml && rm pyproject.toml.bak; \
+	sed -i.bak "1s/^# .*/# $(name)/" README.md && rm README.md.bak; \
+	sed -i.bak "s|<b>.*</b>|<b>$(description)</b>|" README.md && rm README.md.bak
 	@echo "$(GREEN)✅ Updated project name and description.$(RESET)"
 
 banner: check_uv ## Generate project banner image

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ init: ## Initialize project (usage: make init name=my-project description="my de
 	ESC_NAME=$$(printf '%s\n' "$$CURRENT_NAME" | sed 's/[.[\*^$$\/]/\\&/g'); \
 	ESC_DESC=$$(printf '%s\n' "$$CURRENT_DESC" | sed 's/[.[\*^$$\/]/\\&/g'); \
 	ESC_NEW_NAME=$$(printf '%s\n' "$(name)" | sed 's/[&/\\]/\\&/g'); \
-	ESC_NEW_DESC=$$(printf '%s\n' "$(description)" | sed 's/[&|\\]/\\&/g'); \
+	ESC_NEW_DESC=$$(printf '%s\n' "$(description)" | sed 's/[&/|\\]/\\&/g'); \
 	echo "$(YELLOW)🚀 Initializing project $(name)...$(RESET)"; \
 	sed -i.bak "s/name = \"$$ESC_NAME\"/name = \"$$ESC_NEW_NAME\"/" pyproject.toml && rm pyproject.toml.bak; \
 	sed -i.bak "s/description = \"$$ESC_DESC\"/description = \"$$ESC_NEW_DESC\"/" pyproject.toml && rm pyproject.toml.bak; \

--- a/common/global_config.py
+++ b/common/global_config.py
@@ -189,9 +189,9 @@ class Config(BaseSettings):
         default_factory=lambda: os.getenv("GITHUB_ACTIONS") != "true"
     )
     running_on: str = Field(
-        default_factory=lambda: "🖥️  local"
-        if os.getenv("GITHUB_ACTIONS") != "true"
-        else "☁️  CI"
+        default_factory=lambda: (
+            "🖥️  local" if os.getenv("GITHUB_ACTIONS") != "true" else "☁️  CI"
+        )
     )
 
     @classmethod


### PR DESCRIPTION
## Summary
- `make init` used hardcoded strings (`"python-template"`, `"Add your description here"`, etc.) so it silently failed when run on an already-renamed project
- Now dynamically reads current name/description from `pyproject.toml` before replacing, making `make init` idempotent and re-runnable
- Uses flexible regex patterns for README updates instead of exact string matches

Mirrors the fix in https://github.com/Miyamura80/CLI-Template/pull/21

## Test plan
- [ ] Run `make init name=foo description="bar"` on a fresh template — verify pyproject.toml and README update
- [ ] Run `make init name=baz description="qux"` again — verify it re-renames correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)