### PR TITLE
docs: fix outdated documentation (automated weekly drift check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Opinionated Python stack for fast development. The `saas` branch extends `main` 
 - `make all` - sync deps and run `main.py`
 - `make fmt` - runs `ruff format` + JSON formatting
 - `make test` - runs all tests in `tests/`
-- `make ci` - runs all CI checks (ruff, vulture, ty, etc.)
+- `make ci` - runs all CI checks (ruff, vulture, import_lint, ty, docs_lint, lint_links, check_deps)
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,7 @@ This is a Next.js application generated with
 Run development server:
 
 ```bash
-npm run dev
-# or
-pnpm dev
-# or
-yarn dev
+bun run dev
 ```
 
 Open http://localhost:3000 with your browser to see the result.


### PR DESCRIPTION
Fix outdated documentation rules according to `OUTDATED_DOCUMENTATION_GUIDELINE.md` by targeting verifiable factual inaccuracies only.

Changes:
1. Updated `docs/README.md` to use `bun run dev` instead of `npm/pnpm/yarn` instructions, which aligns with `Makefile` and `bun.lock`.
2. Replaced the "etc." reference in `README.md` for the `make ci` description with the concrete list of commands the Makefile target actually runs.

All changes verified with `make lint_links` and `make test`.

---
*PR created automatically by Jules for task [15517131570510791218](https://jules.google.com/task/15517131570510791218) started by @Miyamura80*