### PR TITLE
🐛 migrate langfuse v3 API to v4, remove type: ignore

### DIFF
--- a/utils/llm/dspy_langfuse.py
+++ b/utils/llm/dspy_langfuse.py
@@ -4,7 +4,8 @@ from typing import Any, Literal
 from dspy.adapters import Image as dspy_Image
 from dspy.signatures import Signature as dspy_Signature
 from dspy.utils.callback import BaseCallback
-from langfuse import Langfuse, LangfuseGeneration, get_client
+from langfuse import Langfuse, LangfuseGeneration, LangfuseSpan, get_client
+from langfuse.types import TraceContext
 from litellm.cost_calculator import completion_cost
 from loguru import logger as log
 from pydantic import BaseModel, Field, ValidationError
@@ -60,7 +61,7 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
         self.input_field_values = contextvars.ContextVar[dict[str, Any]](
             "input_field_values"
         )
-        self.current_tool_span = contextvars.ContextVar[Any | None]("current_tool_span")
+        self.current_tool_span = contextvars.ContextVar[LangfuseSpan | None]("current_tool_span")
         # Initialize Langfuse client
         self.langfuse: Langfuse = Langfuse()
         self.input_field_names = signature.input_fields.keys()
@@ -137,11 +138,14 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
         parent_observation_id = get_client().get_current_observation_id()
         span_obj: LangfuseGeneration | None = None
         if trace_id:
-            span_obj = self.langfuse.generation(  # type: ignore[attr-defined]
+            trace_context: TraceContext = {"trace_id": trace_id}
+            if parent_observation_id:
+                trace_context["parent_span_id"] = parent_observation_id
+            span_obj = self.langfuse.start_observation(
+                name=model_name or "unknown",
+                as_type="generation",
                 input=user_input,
-                name=model_name,
-                trace_id=trace_id,
-                parent_observation_id=parent_observation_id,
+                trace_context=trace_context,
                 metadata={
                     "model": model_name,
                     "temperature": temperature,
@@ -347,14 +351,13 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
 
         # --- Finalize Span ---
         if span:
-            end_args: dict[str, Any] = {
-                "output": completion_content,
-                "model": model_name,
-                "level": level,
-                "status_message": status_message,
-            }
-            # Langfuse client's `end` method handles None for these specific optional parameters.
-            span.end(**end_args)
+            span.update(
+                output=completion_content,
+                model=model_name,
+                level=level,
+                status_message=status_message,
+            )
+            span.end()
             self.current_span.set(None)
 
         if level == "DEFAULT" and completion_content is not None:
@@ -396,11 +399,14 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
 
         if trace_id:
             # Create a span for the tool call
-            tool_span = self.langfuse.span(  # type: ignore[attr-defined]
+            trace_context: TraceContext = {"trace_id": trace_id}
+            if parent_observation_id:
+                trace_context["parent_span_id"] = parent_observation_id
+            tool_span = self.langfuse.start_observation(
                 name=f"tool:{tool_name}",
-                trace_id=trace_id,
-                parent_observation_id=parent_observation_id,
+                as_type="span",
                 input=tool_args,
+                trace_context=trace_context,
                 metadata={
                     "tool_name": tool_name,
                     "tool_type": "function",
@@ -437,11 +443,12 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
                 except (TypeError, AttributeError, RecursionError) as e:
                     output_value = {"serialization_error": str(e), "raw": str(outputs)}
 
-            tool_span.end(
+            tool_span.update(
                 output=output_value,
                 level=level,
                 status_message=status_message,
             )
+            tool_span.end()
             self.current_tool_span.set(None)
 
             log.debug(f"Tool call ended with output: {str(output_value)[:100]}...")

--- a/utils/llm/dspy_langfuse.py
+++ b/utils/llm/dspy_langfuse.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 from dspy.adapters import Image as dspy_Image
 from dspy.signatures import Signature as dspy_Signature
 from dspy.utils.callback import BaseCallback
-from langfuse import Langfuse, LangfuseGeneration, LangfuseSpan, get_client
+from langfuse import Langfuse, LangfuseGeneration, LangfuseTool, get_client
 from langfuse.types import TraceContext
 from litellm.cost_calculator import completion_cost
 from loguru import logger as log
@@ -61,7 +61,7 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
         self.input_field_values = contextvars.ContextVar[dict[str, Any]](
             "input_field_values"
         )
-        self.current_tool_span = contextvars.ContextVar[LangfuseSpan | None]("current_tool_span")
+        self.current_tool_span = contextvars.ContextVar[LangfuseTool | None]("current_tool_span")
         # Initialize Langfuse client
         self.langfuse: Langfuse = Langfuse()
         self.input_field_names = signature.input_fields.keys()
@@ -404,7 +404,7 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
                 trace_context["parent_span_id"] = parent_observation_id
             tool_span = self.langfuse.start_observation(
                 name=f"tool:{tool_name}",
-                as_type="span",
+                as_type="tool",
                 input=tool_args,
                 trace_context=trace_context,
                 metadata={


### PR DESCRIPTION
## Summary
- Migrate from removed Langfuse v3 methods (`.generation()`, `.span()`) to v4 `start_observation()` API with `as_type` parameter
- Fix `.end()` calls that passed kwargs no longer accepted in v4 — split into `.update()` + `.end()`
- Import `TraceContext` TypedDict for proper `trace_id`/`parent_span_id` handling
- Tighten `current_tool_span` type from `Any | None` to `LangfuseSpan | None`
- Remove all `type: ignore[attr-defined]` suppressions — `make ci` passes with zero errors

## Test plan
- [ ] Verify `make ci` passes (ruff, vulture, ty, import lint, docs lint)
- [ ] Integration test with live Langfuse: trigger an LLM call and confirm generation spans appear correctly
- [ ] Integration test with live Langfuse: trigger a tool call and confirm tool spans appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)