### PR TITLE
docs: fix outdated documentation

### DIFF
--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -14,7 +14,7 @@ Use the following `make` targets to ensure code quality:
 - `make ruff`: Runs the `ruff` linter to catch common errors and style issues.
 - `make vulture`: Searches for dead code across the project.
 - `make ty`: Runs the `ty` type checker to ensure type safety.
-- `make ci`: Runs all of the above checks (`ruff`, `vulture`, `import_lint`, `ty`, `docs_lint`, `check_deps`) in sequence.
+- `make ci`: Runs all of the above checks (`ruff`, `vulture`, `import_lint`, `ty`, `docs_lint`, `lint_links`, `check_deps`, `file_len_check`) in sequence.
 
 ## Workflow
 

--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -39,7 +39,7 @@ Take a PRD (markdown file or text) and convert it to `prd.json` in your ralph di
 
 **Each story must be completable in ONE Ralph iteration (one context window).**
 
-Ralph spawns a fresh Claude Code/OpenCode instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
+Ralph spawns a fresh Claude Code instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
 
 ### Right-sized stories:
 - Add a database column and migration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ make ruff           # Run ruff linter
 make vulture        # Find dead code
 make ty             # Run type checker
 make lint_links     # Check for broken links in markdown files (README, etc.)
-make ci             # Run all CI checks (ruff, vulture, ty, import_lint, docs_lint, check_deps, lint_links)
+make ci             # Run all CI checks (ruff, vulture, ty, import_lint, docs_lint, check_deps, lint_links, file_len_check)
 
 # Dependencies
 uv sync             # Install dependencies (not pip install)

--- a/UNNECESSARY_CODE_GUIDELINE.md
+++ b/UNNECESSARY_CODE_GUIDELINE.md
@@ -50,7 +50,7 @@ static analysis:
 11. **Migration files**: Database migration scripts.
 12. **Protocol/ABC implementations**: Methods implementing an abstract base
     class or Protocol interface.
-13. **Vulture whitelist entries**: Anything referenced in
+13. **Vulture exclusions**: Anything referenced in
     `pyproject.toml [tool.vulture]` exclusions.
 
 ## Validation Before Removal


### PR DESCRIPTION
Scanned for and fixed outdated documentation based on actual project behavior, strictly following OUTDATED_DOCUMENTATION_GUIDELINE.md and modifying only English source files.

Fixes include:
- Removing OpenCode reference in Ralph SKILL.md.
- Updating `make ci` references to match the actual Makefile target.
- Correcting terminology in UNNECESSARY_CODE_GUIDELINE.md to match pyproject.toml's vulture exclusions.

---
*PR created automatically by Jules for task [5075091126900379835](https://jules.google.com/task/5075091126900379835) started by @Miyamura80*