### PR TITLE
docs: fix outdated documentation (automated weekly drift check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ make ruff           # Run ruff linter
 make vulture        # Find dead code
 make ty             # Run type checker
 make lint_links     # Check for broken links in markdown files (README, etc.)
-make ci             # Run all CI checks (ruff, vulture, ty, import_lint, docs_lint, check_deps, lint_links)
+make ci             # Run all CI checks (ruff, vulture, ty, import_lint, docs_lint, check_deps, lint_links, file_len_check)
 
 # Dependencies
 uv sync             # Install dependencies (not pip install)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,7 @@ This is a Next.js application generated with
 Run development server:
 
 ```bash
-npm run dev
-# or
-pnpm dev
-# or
-yarn dev
+bun run dev
 ```
 
 Open http://localhost:3000 with your browser to see the result.

--- a/scripts/check_file_length.py
+++ b/scripts/check_file_length.py
@@ -46,7 +46,9 @@ def main() -> int:
             violations.append((rel, line_count))
 
     if violations:
-        print(f"File length check failed: {len(violations)} file(s) exceed {max_lines} lines")
+        print(
+            f"File length check failed: {len(violations)} file(s) exceed {max_lines} lines"
+        )
         for rel_path, count in sorted(violations):
             print(f"  {rel_path}: {count} lines")
         print(

--- a/utils/llm/dspy_langfuse.py
+++ b/utils/llm/dspy_langfuse.py
@@ -61,7 +61,9 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
         self.input_field_values = contextvars.ContextVar[dict[str, Any]](
             "input_field_values"
         )
-        self.current_tool_span = contextvars.ContextVar[LangfuseTool | None]("current_tool_span")
+        self.current_tool_span = contextvars.ContextVar[LangfuseTool | None](
+            "current_tool_span"
+        )
         # Initialize Langfuse client
         self.langfuse: Langfuse = Langfuse()
         self.input_field_names = signature.input_fields.keys()


### PR DESCRIPTION
Fixes outdated documentation drift in `docs/README.md` and `CLAUDE.md`.

- Updates `docs/README.md` to use `bun run dev` instead of `npm run dev`/`yarn dev`/`pnpm dev`.
- Updates `CLAUDE.md` to include the `file_len_check` check in the documentation for the `make ci` target.

---
*PR created automatically by Jules for task [288701422374416157](https://jules.google.com/task/288701422374416157) started by @Miyamura80*