### PR TITLE
⚙️ ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ old_scripts/
 
 # Agent session files
 session-*.md
+.claude/scheduled_tasks.lock
 
 # Overwrite global config
 .global_config.yaml


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to `.gitignore` so Claude Code's scheduled task lock file stays out of version control.

## Test plan
- [x] `.gitignore` updated