### PR TITLE
Enable BLE linting rule and add noqa comments for intentional exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ line-length = 88
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "B", "C4", "SIM", "C901", "FIX"]
+select = ["E", "F", "W", "I", "N", "UP", "B", "C4", "SIM", "C901", "FIX", "BLE"]
 ignore = ["E501", "UP015", "B008"]
 
 [tool.ruff.lint.mccabe]

--- a/tests/test_logging_thread_safety.py
+++ b/tests/test_logging_thread_safety.py
@@ -30,7 +30,7 @@ class TestLoggingThreadSafety(TestTemplate):
             try:
                 barrier.wait(timeout=5)
                 logging_module.setup_logging()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - test collects any thread failure
                 errors.append(e)
 
         threads = [threading.Thread(target=call_setup) for _ in range(10)]

--- a/utils/llm/dspy_langfuse.py
+++ b/utils/llm/dspy_langfuse.py
@@ -102,7 +102,7 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
                 outputs_extracted = dict(outputs.items())
             except AttributeError:
                 outputs_extracted = {"value": outputs}
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - observability fallback must never raise
                 outputs_extracted = {"error_extracting_module_output": str(e)}
         get_client().update_current_span(
             input=self.input_field_values.get(None) or {},


### PR DESCRIPTION
## Summary

Enable the BLE (blind except) linting rule in Ruff to catch overly broad exception handling, and add appropriate `noqa` comments to intentional cases where catching all exceptions is necessary.

## Changes

- Added "BLE" to the Ruff lint rules in `pyproject.toml` to enforce more specific exception handling
- Added `noqa: BLE001` comments to two legitimate cases where catching all exceptions is intentional:
  - `tests/test_logging_thread_safety.py`: Test needs to collect any thread failure regardless of exception type
  - `utils/llm/dspy_langfuse.py`: Observability fallback must never raise, so it catches all exceptions to ensure robustness

## Testing

- [x] Linting passes (`make ci`)
- [x] Tests pass (`make test`)

https://claude.ai/code/session_01LKvQDaUrRDui7ZQRkHH4Cp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the BLE lint rule in `ruff` to flag broad exception handling (Linear BAVB9). Add `# noqa: BLE001` to the two intentional catch-alls in tests/test_logging_thread_safety.py and utils/llm/dspy_langfuse.py.

<sup>Written for commit a15b0c821d09b7a33fa9158322fe7835c3787a89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

