### PR TITLE
chore: prune unnecessary code (automated weekly cleanup)

### DIFF
--- a/utils/llm/dspy_langfuse.py
+++ b/utils/llm/dspy_langfuse.py
@@ -300,7 +300,6 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
                         "input": final_prompt_tokens,
                         "output": final_completion_tokens,
                         "total": final_total_tokens,
-                        # "cache_read_input_tokens": 0, # Optional: if you track this
                     }
                     cost_details_update = {
                         "input": (
@@ -317,7 +316,6 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
                             else 0.0
                         ),
                         "total": total_cost,
-                        # "cache_read_input_tokens": 0.0, # Optional
                     }
                     span.update(
                         usage_details=usage_details_update,
@@ -349,7 +347,6 @@ class LangFuseDSPYCallback(BaseCallback):  # noqa
                 log.warning(
                     f"Missing required information for full usage/cost calculation: {', '.join(missing_info_elements)}"
                 )
-                # status_message = (status_message + "; " if status_message else "") + f"Missing info for cost calc: { ', '.join(missing_info_elements)}"
 
         # --- Finalize Span ---
         if span:


### PR DESCRIPTION
This PR removes commented-out code from `utils/llm/dspy_langfuse.py` that is not used. 
It strictly follows `UNNECESSARY_CODE_GUIDELINE.md` and only removes dead code that is safely identified as unused, leaving required Pydantic settings methods and test fixtures in place.

---
*PR created automatically by Jules for task [14415639592093320777](https://jules.google.com/task/14415639592093320777) started by @Miyamura80*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pruned commented-out dead code in `utils/llm/dspy_langfuse.py` to keep the file clean and reduce maintenance noise. No behavior or API changes.

- **Refactors**
  - Removed commented `cache_read_input_tokens` fields and an unused status message update in `on_lm_end`.
  - Followed `UNNECESSARY_CODE_GUIDELINE.md`; left Pydantic settings and test fixtures intact.

<sup>Written for commit ac77f914cc565d206565175b1defa662be1134e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

