### PR TITLE
docs: fix outdated documentation (automated weekly drift check)

### DIFF
--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -116,7 +116,7 @@ Detect package manager and sync:
 - If `uv.lock` exists: `uv sync`
 - Else if `bun.lockb` exists: `bun install`
 - Else if `package-lock.json` exists: `npm install`
-- Else if `requirements.txt` exists: `pip install -r requirements.txt`
+- Else if `requirements.txt` exists: `uv pip install -r requirements.txt`
 - Else: Skip dependency sync
 
 ### 11. Git garbage collection

--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -14,7 +14,7 @@ Use the following `make` targets to ensure code quality:
 - `make ruff`: Runs the `ruff` linter to catch common errors and style issues.
 - `make vulture`: Searches for dead code across the project.
 - `make ty`: Runs the `ty` type checker to ensure type safety.
-- `make ci`: Runs all of the above checks (`ruff`, `vulture`, `import_lint`, `ty`, `docs_lint`, `check_deps`) in sequence.
+- `make ci`: Runs all of the above checks (`ruff`, `vulture`, `import_lint`, `ty`, `docs_lint`, `lint_links`, `check_deps`, `file_len_check`) in sequence.
 
 ## Workflow
 

--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -39,7 +39,7 @@ Take a PRD (markdown file or text) and convert it to `prd.json` in your ralph di
 
 **Each story must be completable in ONE Ralph iteration (one context window).**
 
-Ralph spawns a fresh Claude Code/OpenCode instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
+Ralph spawns a fresh Claude Code instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
 
 ### Right-sized stories:
 - Add a database column and migration


### PR DESCRIPTION
Fixes several instances of documentation drift identified across the `.claude/skills/` directory.

- The `make ci` description in `code-quality` SKILL was missing `lint_links` and `file_len_check`.
- The `cleanup` SKILL was using `pip install -r requirements.txt` instead of the required `uv pip install -r requirements.txt` for `requirements.txt` fallback scenarios.
- The `ralph` SKILL referred to `OpenCode`, which has been globally replaced with `Claude Code` per memory instructions.

Verified that markdown syntax is intact, translation files are not touched, and `make ci` + `make test` are passing cleanly.

---
*PR created automatically by Jules for task [6155697974766177135](https://jules.google.com/task/6155697974766177135) started by @Miyamura80*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes documentation drift in `.claude/skills` to match current tooling and naming. Keeps the quality checks accurate and dependency setup consistent.

- **Bug Fixes**
  - Updated `make ci` description to include `lint_links` and `file_len_check` in `.claude/skills/code-quality/SKILL.md`.
  - Switched `pip install -r requirements.txt` to `uv pip install -r requirements.txt` in `.claude/skills/cleanup/SKILL.md`.
  - Replaced "OpenCode" with "Claude Code" in `.claude/skills/ralph/SKILL.md`.

<sup>Written for commit e4f16ff22aaad85aea0fae204a2497d9d544b19c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Miyamura80/Python-Template/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

