### PR TITLE
docs: fix outdated documentation (automated weekly drift check)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -39,7 +39,7 @@ Take a PRD (markdown file or text) and convert it to `prd.json` in your ralph di
 
 **Each story must be completable in ONE Ralph iteration (one context window).**
 
-Ralph spawns a fresh Claude Code/OpenCode instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
+Ralph spawns a fresh Claude Code instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
 
 ### Right-sized stories:
 - Add a database column and migration


### PR DESCRIPTION
Fix outdated documentation based on drift check:

- File: `.claude/skills/ralph/SKILL.md`, line 42
- Issue: Mentioned "OpenCode" which is deprecated.
- Fix: Replaced "Claude Code/OpenCode instance" with "Claude Code instance"
- Evidence: Project memory states that references to 'OpenCode' should be replaced with 'Claude Code' in project documentation and scripts.

---
*PR created automatically by Jules for task [5074828075643195603](https://jules.google.com/task/5074828075643195603) started by @Miyamura80*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix outdated documentation by replacing the deprecated "OpenCode" term with "Claude Code" in `.claude/skills/ralph/SKILL.md` to align with current naming and avoid confusion.

<sup>Written for commit 96398b7a517d2093625686e0646db21410a79d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Miyamura80/Python-Template/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

