### PR TITLE
docs: fix outdated documentation

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -39,7 +39,7 @@ Take a PRD (markdown file or text) and convert it to `prd.json` in your ralph di
 
 **Each story must be completable in ONE Ralph iteration (one context window).**
 
-Ralph spawns a fresh Claude Code/OpenCode instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
+Ralph spawns a fresh Claude Code instance per iteration with no memory of previous work. If a story is too big, the LLM runs out of context before finishing and produces broken code.
 
 ### Right-sized stories:
 - Add a database column and migration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,11 +44,11 @@ uv run pytest path/to/test.py  # Run specific test
 
 ## Architecture
 
+- **.env** - Secrets/API keys located at the root of the repo (git-ignored)
 - **common/** - Global configuration via pydantic-settings
   - `global_config.yaml` - Base hyperparameters and config values
   - `<name>.yaml` - Optional split configs (loaded as root key `<name>`)
   - `global_config.py` - Config class (access via `from common import global_config`)
-  - `.env` - Secrets/API keys (git-ignored)
 - **src/** - Source code (utils/)
 - **utils/llm/** - LLM inference with DSPY (`dspy_inference.py`) and LangFuse observability
 - **tests/** - pytest tests inheriting from `TestTemplate` in `test_template.py`


### PR DESCRIPTION
Fixes documentation drift based on `OUTDATED_DOCUMENTATION_GUIDELINE.md` and memory directives. 

- Moved `.env` reference to root in `CLAUDE.md` Architecture section.
- Replaced "OpenCode" with "Claude Code" in `.claude/skills/ralph/SKILL.md`.
- `AGENTS.md` is a symlink to `CLAUDE.md`, so changes were automatically reflected.

---
*PR created automatically by Jules for task [9515861239241997346](https://jules.google.com/task/9515861239241997346) started by @Miyamura80*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed documentation drift by moving the `.env` reference to the repo root in `CLAUDE.md` and updating "OpenCode" to "Claude Code" in `.claude/skills/ralph/SKILL.md`.
This aligns the docs with current project structure and naming.

<sup>Written for commit 9664c48e3b0af41737566d9fb510b35e26786dd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Miyamura80/Python-Template/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

